### PR TITLE
Fix isdominated in exact.jl bounds definition

### DIFF
--- a/src/exact.jl
+++ b/src/exact.jl
@@ -78,15 +78,11 @@ function isdominated(A, b, islb, isfun, k, optimizer_constructor, lb, ub, epsilo
         end
     end
 
-    # update lower and upper bound if Vector
-    lbx = isa(lb, Vector) ? vcat(-Inf, lb) : lb
-    ubx = isa(ub, Vector) ? vcat(Inf, ub) : ub
-
     # solve the LP with JuMP
     model = Model(optimizer_constructor)
     z = @variable(model, [1:nx+1])
-    set_lower_bound.(z, lbx)
-    set_upper_bound.(z, ubx)
+    set_lower_bound.(z[2:end], lb)
+    set_upper_bound.(z[2:end], ub)
 
     @constraint(model, H * z .≤ h)
     @objective(model, Min, c ⋅ z)

--- a/src/exact.jl
+++ b/src/exact.jl
@@ -85,12 +85,8 @@ function isdominated(A, b, islb, isfun, k, optimizer_constructor, lb, ub, epsilo
     # solve the LP with JuMP
     model = Model(optimizer_constructor)
     z = @variable(model, [1:nx+1])
-    if lb isa Vector
-        set_lower_bound.(z, lb)
-    end
-    if ub isa Vector
-        set_upper_bound.(z, ub)
-    end
+    set_lower_bound.(z, lbx)
+    set_upper_bound.(z, ubx)
 
     @constraint(model, H * z .≤ h)
     @objective(model, Min, c ⋅ z)

--- a/test/exact.jl
+++ b/test/exact.jl
@@ -30,6 +30,26 @@ isempty(lp_solvers) && warn("Exact Pruning tests not run!")
             exactpruning!(pruner, optimizer_constructor)
             # perform the same test again
             @test pruner.b == [10, 20]
+
+            pruner = CutPruner{1, Int}(algo, :Max)
+
+            addcuts!(pruner, [1]', [0], [true])
+            addcuts!(pruner, [-1]', [1], [true])
+            exactpruning!(pruner, optimizer_constructor, lb = 0.5)
+            @test pruner.b == [0]
+
+            addcuts!(pruner, [-1]', [1], [true])
+            exactpruning!(pruner, optimizer_constructor, lb = [0.5])
+            @test pruner.b == [0]
+
+            addcuts!(pruner, [-1]', [1], [true])
+            exactpruning!(pruner, optimizer_constructor, ub = 0.4)
+            @test pruner.b == [1]
+
+            addcuts!(pruner, [1]', [0], [true])
+            exactpruning!(pruner, optimizer_constructor, ub = [0.4])
+            @test pruner.b == [1]
+
         end
     end
     for algo in [AvgCutPruningAlgo(20), DecayCutPruningAlgo(20), DeMatosPruningAlgo(20)]


### PR DESCRIPTION
I think there must be a mistake in the function `isdominated` in `exact.jl`. 
It was changed to transition from  `MathProgBase.linprog` to JuMP + MOI.

The user has to define bounds `lb` and `ub` as vectors whose size are not  `size(A,2)`  but `size(A,2)+1.` 
Two variables `lbx` and `ubx,` are defined to avoid that, but they were not properly used.

All tests pass with this fix !